### PR TITLE
Update get query to allow filter by date

### DIFF
--- a/garnbarn_api/views.py
+++ b/garnbarn_api/views.py
@@ -12,7 +12,7 @@ class AssignmentViewset(viewsets.ModelViewSet):
     def get_queryset(self):
         if self.request.query_params.get('fromPresent') == "true":
             data = Assignment.objects.exclude(
-                due_date__lt=datetime.now()).order_by('id')
+                due_date__lt=datetime.now()).order_by('due_date')
         else:
             data = Assignment.objects.get_queryset().order_by('id')
         return data


### PR DESCRIPTION
Overwrite get_queryset method to be able to get assignment's objects that filtered by dueDate.

<!-- Write your PR Details here -->

## PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Others. (Please describe)

## PR Info.

### Changes

<!--Write what have been changed-->

AssignmentViewset.get_queryset() when calling .../api/v1/assignment/?fromPresent=true
this will return all assignment's object with dueDate > now.


