### PR TITLE
HotFix: CustomUser is not JSON serializable

### DIFF
--- a/garnbarn_api/serializer.py
+++ b/garnbarn_api/serializer.py
@@ -39,12 +39,14 @@ class ReminderTimeField(serializers.ListField):
 
 class TagIdField(serializers.Field):
     def to_representation(self, value):
+        author = value.author.uid if value.author else None
         return {
             "id": value.id,
             "name": value.name,
-            "author": value.author,
+            "author": author,
             "color": value.color,
-            "reminderTime": value.reminder_time
+            "reminderTime": value.reminder_time,
+            "subscriber": value.subscriber
         }
 
     def to_internal_value(self, value):
@@ -118,7 +120,7 @@ class CreateAssignmentApiSerializer(serializers.ModelSerializer):
     reminderTime = ReminderTimeField(source='reminder_time', default=None,
                                      child=serializers.IntegerField()
                                      )
-    tag = CreateTagApiSerializer(default=None)
+    tag = TagIdField(default=None)
 
     class Meta:
         model = Assignment

--- a/garnbarn_api/serializer.py
+++ b/garnbarn_api/serializer.py
@@ -66,28 +66,37 @@ class UserSerializer(serializers.ModelSerializer):
         read_only_fields = ['uid']
 
 
-class GetAssignmentApiSerializer(serializers.ModelSerializer):
-    tag = TagIdField()
-    name = serializers.CharField(source='assignment_name')
-    dueDate = TimestampField(source='due_date', default=None)
-    timestamp = TimestampField(default=None)
-    author = serializers.PrimaryKeyRelatedField(source='author.uid', read_only=True, default=None)
+class CreateTagApiSerializer(serializers.ModelSerializer):
+    """Serializer for Create Tag API
+
+    template:
+        {
+            "id": 1
+            "name": "example_tag_name"
+            "color": "example_color"
+        }
+    """
     reminderTime = ReminderTimeField(source='reminder_time', default=None,
                                      child=serializers.IntegerField()
                                      )
+    author = serializers.PrimaryKeyRelatedField(
+        source='author.uid', read_only=True, default=None)
+    subscriber = serializers.ListField(default=None,
+                                       child=serializers.CharField()
+                                       )
 
     class Meta:
-        model = Assignment
-        fields = [
-            "id",
-            "tag",
-            "author",
-            "name",
-            "dueDate",
-            "timestamp",
-            "description",
-            "reminderTime",
-        ]
+        model = Tag
+        fields = ['id',
+                  'name',
+                  'author',
+                  'color',
+                  'reminderTime',
+                  'subscriber'
+                  ]
+        depth = 1
+
+        read_only_fields = ['author']
 
 
 class CreateAssignmentApiSerializer(serializers.ModelSerializer):
@@ -109,6 +118,7 @@ class CreateAssignmentApiSerializer(serializers.ModelSerializer):
     reminderTime = ReminderTimeField(source='reminder_time', default=None,
                                      child=serializers.IntegerField()
                                      )
+    tag = CreateTagApiSerializer(default=None)
 
     class Meta:
         model = Assignment
@@ -150,47 +160,14 @@ class UpdateAssignmentApiSerializer(serializers.ModelSerializer):
         read_only_fields = ['tagId', ]
 
 
-class CreateTagApiSerializer(serializers.ModelSerializer):
-    """Serializer for Create Tag API
-
-    template:
-        {
-            "id": 1
-            "name": "example_tag_name"
-            "color": "example_color"
-        }
-    """
-    reminderTime = ReminderTimeField(source='reminder_time', default=None,
-                                        child=serializers.IntegerField()
-                                        )
-    author = serializers.PrimaryKeyRelatedField(
-        source='author.uid', read_only=True, default=None)
-    subscriber = serializers.ListField(default=None,
-                                        child=serializers.CharField()
-                                        )
-
-    class Meta:
-        model = Tag
-        fields = ['id',
-                  'name',
-                  'author',
-                  'color',
-                  'reminderTime',
-                  'subscriber'
-                  ]
-        depth = 1
-
-        read_only_fields = ['author']
-
-
 class UpdateTagApiSerializer(serializers.ModelSerializer):
     """Serializer for the Update Tag API"""
     reminderTime = ReminderTimeField(source='reminder_time', default=None,
-                                        child=serializers.IntegerField()
-                                        )
+                                     child=serializers.IntegerField()
+                                     )
     subscriber = serializers.ListField(default=None,
-                                        child=serializers.CharField()
-                                        )
+                                       child=serializers.CharField()
+                                       )
 
     class Meta:
         model = Tag
@@ -203,6 +180,7 @@ class UpdateTagApiSerializer(serializers.ModelSerializer):
                   ]
         depth = 1
         read_only_fields = ['author']
+
 
 class CustomUserSerializer(serializers.ModelSerializer):
     """Serializer for user object

--- a/garnbarn_api/serializer.py
+++ b/garnbarn_api/serializer.py
@@ -120,7 +120,7 @@ class CreateAssignmentApiSerializer(serializers.ModelSerializer):
     reminderTime = ReminderTimeField(source='reminder_time', default=None,
                                      child=serializers.IntegerField()
                                      )
-    tag = TagIdField(default=None)
+    tag = TagIdField(default=None, read_only=True)
 
     class Meta:
         model = Assignment
@@ -135,7 +135,7 @@ class CreateAssignmentApiSerializer(serializers.ModelSerializer):
                   ]
         depth = 1
 
-        read_only_fields = ['timestamp', 'author']
+        read_only_fields = ['timestamp', 'author', 'tag']
 
 
 class UpdateAssignmentApiSerializer(serializers.ModelSerializer):

--- a/garnbarn_api/tests/test_view.py
+++ b/garnbarn_api/tests/test_view.py
@@ -51,7 +51,8 @@ class ViewTests(APITestCase):
         )
         self.assignment.save()
 
-        self.tag2 = Tag.objects.create(name="test_tag2", color='#4285F4', author=self.user)
+        self.tag2 = Tag.objects.create(
+            name="test_tag2", color='#4285F4', author=self.user)
 
     def test_assignment_not_existed_assignment(self):
         """Raise 404 status code when assignment's object does not exist"""
@@ -78,6 +79,7 @@ class ViewTests(APITestCase):
                 "author": None,
                 "color": '#4285F4',
                 "reminderTime": None,
+                "subscriber": None
             },
             "name": "assignment 1",
             "dueDate": self.end_date_timestamp,
@@ -287,8 +289,8 @@ class ViewTests(APITestCase):
             'color': '#4285F9',
         })
         response = self.client.patch("/api/v1/tag/1/", data,
-                                    content_type="application/json"
-                                    )
+                                     content_type="application/json"
+                                     )
         converted_data = convert_to_json(response.content)
         expected_result = json.dumps({
             'id': 1,

--- a/garnbarn_api/views.py
+++ b/garnbarn_api/views.py
@@ -59,6 +59,10 @@ class AssignmentViewset(viewsets.ModelViewSet):
                 return Response({
                     'message': "tagId must be able to be converted to an integer"
                 }, status=status.HTTP_400_BAD_REQUEST)
+            except TypeError:
+                return Response({
+                    'message': "tagId must be able to be converted to an integer"
+                }, status=status.HTTP_400_BAD_REQUEST)
 
         assignment_object.save()
         return Response(assignment_object.get_json_data(), status=status.HTTP_200_OK)

--- a/garnbarn_api/views.py
+++ b/garnbarn_api/views.py
@@ -13,7 +13,7 @@ from .models import Assignment, Tag
 class AssignmentViewset(viewsets.ModelViewSet):
     authentication_classes = [FirebaseAuthIDTokenAuthentication]
     permission_classes = [IsAuthenticated]
-    serializer_class = garnbarn_serializer.GetAssignmentApiSerializer
+    serializer_class = garnbarn_serializer.CreateAssignmentApiSerializer
 
     def get_queryset(self):
         if self.request.query_params.get('fromPresent') == "true":


### PR DESCRIPTION
<!-- Write your PR Details here -->
#29

## PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Others. (Please describe)

## PR Info.

### Fixes

<!--Write what have been fixed (You can mention issue)-->

1. Calling the GET All API returning the 500 telling that CustomUser is not JSON serializable. #29
2. tagIdField returns author's uid instead of author object.
